### PR TITLE
Add 'pwi' as an auto-detected extension

### DIFF
--- a/ftdetect/espresso.vim
+++ b/ftdetect/espresso.vim
@@ -1,3 +1,4 @@
 au BufRead,BufNewFile *.espresso      set filetype=espresso
 au BufRead,BufNewFile *.qe            set filetype=espresso
 au BufRead,BufNewFile *.in            set filetype=espresso
+au BufRead,BufNewFile *.pwi           set filetype=espresso


### PR DESCRIPTION
Some codes like gdis and xcrysden can use '.pwi' for espresso input.